### PR TITLE
fix: Replace auctionCount with _id in Auctions contract

### DIFF
--- a/contracts/Auctions.sol
+++ b/contracts/Auctions.sol
@@ -47,13 +47,13 @@ contract Auctions {
   }
 
   function PlaceBid (uint _id, uint256 _amount) public {
-    require(msg.sender != auctions[auctionCount].owner, "You cannot bid your own auctions!");
-    uint256 oldPrice = auctions[auctionCount].currentPrice;
+    require(msg.sender != auctions[_id].owner, "You cannot bid your own auctions!");
+    uint256 oldPrice = auctions[_id].currentPrice;
     require(_amount - oldPrice >= 1, "Bid amounts should be greater by at least 1 unit!");
 
     Bid memory newBid = Bid(msg.sender, _amount);
     bids[_id].push(newBid);
-    auctions[auctionCount].currentPrice = _amount;
+    auctions[_id].currentPrice = _amount;
     emit PlacedBid(_id, msg.sender, oldPrice, _amount);
   }
 }

--- a/test/Auctions.test.js
+++ b/test/Auctions.test.js
@@ -26,14 +26,12 @@ contract('Auctions', (accounts) => {
   });
 
   it('successfully places a bid', async () => {
-    const auctionCount = await this.auctions.auctionCount();
-
-    const bidResult = await this.auctions.PlaceBid(auctionCount, 2, { from: accounts[1] });
+    const bidResult = await this.auctions.PlaceBid(1, 2, { from: accounts[1] });
     const { currentPrice } = bidResult.logs[0].args;
 
     const event = bidResult.logs[0].args;
 
-    assert.equal(event.id.toNumber(), auctionCount);
+    assert.equal(event.id.toNumber(), 1);
     assert.equal(event.bidder.toLowerCase(), accounts[1].toLowerCase());
     assert.equal(event.oldPrice.toNumber(), 1);
     assert.equal(currentPrice.toNumber(), 2);


### PR DESCRIPTION
- **Issue:** Bid was placed always to the last auction because of auctionCount variable
- **Fix:** Replace auctionCount with _id and change bid auction to the first one in the test